### PR TITLE
Vocabulary edit and description, icon, image field support implemented

### DIFF
--- a/ckanext/vocabulary/blueprints/vocabulary.py
+++ b/ckanext/vocabulary/blueprints/vocabulary.py
@@ -37,14 +37,20 @@ def new():
                 'user': c.user, 'auth_user_obj': c.userobj}
     if not c.userobj.sysadmin:
         base.abort(403, _(u'Unauthorized to create a group'))
+    
+    data_dict = {}
+    errors = {}
+    error_summary = {}
 
     if request.method == 'POST':
         params = clean_dict(
                 dict_fns.unflatten(tuplize_dict(parse_params(request.form))))
-        data_dict = {}
+       
         data_dict['name'] = params['vocabulary']
         data_dict["name_translated-en"] = params['vocabulary']
         data_dict["name_translated-ar"] = params['vocabulary-ar']
+        data_dict["description_translated-en"] = params['description-en']
+        data_dict["description_translated-ar"] = params['description-ar']
 
         ar_tags = params['ar']
         en_tags = params['en']
@@ -64,15 +70,25 @@ def new():
                 'name_translated-en': en_tags,
                 'name_translated-ar': ar_tags
             }]
-        data_dict['tags'] = tags
+        
+        # Only add tags in dict if tag is provided in request params.    
+        if en_tags:
+            data_dict['tags'] = tags
+
         try:
             create_vocab = get_action('vocabulary_create')(context, data_dict)
             h.flash_success(u"Successfully create category.")
             return h.redirect_to(h.url_for('vocabulary_read', id=params['vocabulary']))
         except logic.ValidationError as e:
-            h.flash_error(e.error_dict)
+            errors=e.error_dict
 
-    return render('vocabulary/new.html', {})
+    vars = {
+        'data': data_dict or {}, 
+        'errors': errors or {}, 
+        'error_summary': error_summary or {}
+        }
+    return render('vocabulary/new.html',  extra_vars=vars)
+
 
 
 def read(id):
@@ -99,15 +115,26 @@ def edit(id):
         params = clean_dict(
                 dict_fns.unflatten(tuplize_dict(parse_params(request.form))))
         
+        data_dict = { "id": id}
+        data_dict['name'] = params['vocabulary']
+        data_dict['name_translated-en'] = params['vocabulary']
+        data_dict['name_translated-ar'] = params['vocabulary-ar']
+        data_dict['description_translated-en'] = params['description-en']
+        data_dict['description_translated-ar'] = params['description-ar']
+        data_dict['id'] = id
+        
         try:
-            get_action('vocabulary_update')(context, {'id': id, "name": params['vocabulary']})
+            get_action('vocabulary_update')(context, data_dict)
             h.flash_success(u"Succesfully edit category.")
             return h.redirect_to(h.url_for('vocabulary_read', id=id))
         except logic.ValidationError as e:
             h.flash_error(e.error_dict)
-    
     vocab = get_action('vocabulary_show')(context, {'id': id})
-    return render('vocabulary/edit.html', {"vocab": vocab})
+    errors = {}
+    error_summary = {}
+    vars = {'data': vocab, 'errors': errors}
+
+    return render('vocabulary/edit.html',  extra_vars=vars)
 
 
 def new_tags(id):

--- a/ckanext/vocabulary/blueprints/vocabulary.py
+++ b/ckanext/vocabulary/blueprints/vocabulary.py
@@ -45,12 +45,19 @@ def new():
     if request.method == 'POST':
         params = clean_dict(
                 dict_fns.unflatten(tuplize_dict(parse_params(request.form))))
-       
+        params.update(clean_dict(
+            dict_fns.unflatten(tuplize_dict(parse_params(request.files)))
+        ))           
         data_dict['name'] = params['vocabulary']
         data_dict["name_translated-en"] = params['vocabulary']
         data_dict["name_translated-ar"] = params['vocabulary-ar']
         data_dict["description_translated-en"] = params['description-en']
         data_dict["description_translated-ar"] = params['description-ar']
+
+        if params['image_upload']:
+            data_dict.update({'image_url': params['image_url'], 'image_upload': params['image_upload']})
+        if params['icon_upload']:
+            data_dict.update({'icon_url': params['icon_upload'], 'icon_upload': params['icon_upload']})
 
         ar_tags = params['ar']
         en_tags = params['en']
@@ -114,6 +121,9 @@ def edit(id):
     if request.method == "POST":
         params = clean_dict(
                 dict_fns.unflatten(tuplize_dict(parse_params(request.form))))
+        params.update(clean_dict(
+            dict_fns.unflatten(tuplize_dict(parse_params(request.files)))
+        ))       
         
         data_dict = { "id": id}
         data_dict['name'] = params['vocabulary']
@@ -123,6 +133,16 @@ def edit(id):
         data_dict['description_translated-ar'] = params['description-ar']
         data_dict['id'] = id
         
+        if params['image_upload']:
+            data_dict.update({'image_upload': params['image_upload']})
+        if params['icon_upload']:
+            data_dict.update({'icon_upload': params['icon_upload']})
+            
+        if params['image_url']:
+            data_dict.update({'image_url': params['image_url']})
+        if params['icon_url']:
+            data_dict.update({'icon_url': params['icon_url']})
+
         try:
             get_action('vocabulary_update')(context, data_dict)
             h.flash_success(u"Succesfully edit category.")

--- a/ckanext/vocabulary/templates/vocabulary/edit.html
+++ b/ckanext/vocabulary/templates/vocabulary/edit.html
@@ -1,11 +1,11 @@
 {% import 'macros/form.html' as form %}
 
 {% extends "page.html" %}
-{% block subtitle %}{{ vocab.name }} {{ g.template_title_delimiter }}{{ _('Edit Category') }}{% endblock %}
+{% block subtitle %}{{ data.name }} {{ g.template_title_delimiter }}{{ _('Edit Category') }}{% endblock %}
 {% block breadcrumb_content %}
 <li class="active">{% link_for _('Categories'), named_route='vocabulary.index' %}</li>
-<li class="active">{% link_for vocab.name, named_route='vocabulary.read', id=vocab.name %}</li>
-<li class="active">{% link_for _('Edit'), named_route='vocabulary.edit', id=vocab.name %}</li>
+<li class="active">{% link_for data.name, named_route='vocabulary.read', id=data.name %}</li>
+<li class="active">{% link_for _('Edit'), named_route='vocabulary.edit', id=data.name %}</li>
 {% endblock %}
 
 {% block page_header %}
@@ -16,27 +16,20 @@
 {% set flash_messages = h.flash.pop_messages() %}
     {{ h.literal(message) }}
 <form method="post" data-module="basic-form">
-  <div class="form-group">
-    {{ form.input('vocabulary', label =_('EN NAME'), value=vocab.name)}}
-  </div>
-  {% if vocab.get("name_translated", False) %}
-    <div class="form-group">
-      <label>AR NAME</label>
-      <input type="text" name="vocabulary-ar" class="form-control" dir="rtl" value="{{vocab.name_translated.ar}}">
-    </div>
-  {% else %}
-  <div class="form-group">
-    <label>AR NAME</label>
-    <input type="text" name="vocabulary-ar" class="form-control" dir="rtl">
-  </div>
-  {% endif %}
 
+  
+  {{ form.input('vocabulary', label =_('EN NAME'), value=data.name)}}
+  {{ form.input('vocabulary-ar', label =_('AR NAME'), value=data.name_translated.ar if data.name_translated else  '' )}}
+  {{ form.markdown('description-en', id='description-en', label=_('EN Description'), 
+      value= data.description_translated.en if data.description_translated else  '' )}}
+  {{ form.markdown('description-ar', id='description-ar', label=_('AR Description'), 
+      value=data.description_translated.ar if data.description_translated else '', attrs={'dir': 'rtl'} )}}
 
   <div class="form-actions">
     {% block delete_button %}
-    {% if h.check_access('vocabulary_delete', {'id': vocab.id}) %}
+    {% if h.check_access('vocabulary_delete', {'id': data.id}) %}
     {% set locale = h.dump_json({'content': _('Are you sure you want to delete this Category and all its Tags?')}) %}
-    <a class="btn btn-danger pull-left" href="{{h.url_for('vocabulary.delete', id=vocab.id)}}"
+    <a class="btn btn-danger pull-left" href="{{h.url_for('vocabulary.delete', id=data.id)}}"
       data-module="confirm-action" data-module-i18n="{{ locale }}">{% block delete_button_text %}{{ _('Delete') }}{%
       endblock %}</a>
     {% endif %}

--- a/ckanext/vocabulary/templates/vocabulary/edit.html
+++ b/ckanext/vocabulary/templates/vocabulary/edit.html
@@ -15,15 +15,23 @@
 {% block primary_content_inner %}
 {% set flash_messages = h.flash.pop_messages() %}
     {{ h.literal(message) }}
-<form method="post" data-module="basic-form">
+<form method="post" data-module="basic-form" enctype="multipart/form-data">
 
-  
   {{ form.input('vocabulary', label =_('EN NAME'), value=data.name)}}
   {{ form.input('vocabulary-ar', label =_('AR NAME'), value=data.name_translated.ar if data.name_translated else  '' )}}
   {{ form.markdown('description-en', id='description-en', label=_('EN Description'), 
       value= data.description_translated.en if data.description_translated else  '' )}}
   {{ form.markdown('description-ar', id='description-ar', label=_('AR Description'), 
       value=data.description_translated.ar if data.description_translated else '', attrs={'dir': 'rtl'} )}}
+
+  {% set is_image_upload = data.image_url and not data.image_url.startswith('http') %}
+  {% set is_image_url = data.image_url and data.image_url.startswith('http') %}
+  {{ form.image_upload(data, errors, is_upload_enabled=h.uploads_enabled(), is_url=is_image_url, is_upload=is_image_upload) }}
+
+  {% set is_icon_upload = data.icon_url and not data.icon_url.startswith('http') %}
+  {% set is_icon_url = data.icon_url and data.icon_url.startswith('http') %}
+  {{ form.image_upload(data, errors, is_upload_enabled=h.uploads_enabled(), field_upload='icon_upload',
+  field_url='icon_url', upload_label='Icon', url_label='Icon', is_url=is_icon_url, is_upload=is_icon_upload, ) }}
 
   <div class="form-actions">
     {% block delete_button %}
@@ -40,4 +48,10 @@
 {% endblock %}
 {% block secondary_content %}
   {% snippet "vocabulary/snippets/helper.html" %}
+{% endblock %}
+
+{% block scripts %}
+   {{super()}}
+  {% asset 'ckanext-scheming/upload_js' %}
+  {% asset 'vocab/addtags_js' %}
 {% endblock %}

--- a/ckanext/vocabulary/templates/vocabulary/new.html
+++ b/ckanext/vocabulary/templates/vocabulary/new.html
@@ -15,13 +15,13 @@
     {% set flash_messages = h.flash.pop_messages() %}
     {{ h.literal(message) }}
   <form class="dataset-form" method="post" data-module="basic-form">
-    <div class="form-group">
-      {{ form.input('vocabulary', label =_('EN Name'))}}
-    </div>
-    <div class="form-group">
-      <label>AR NAME</label>
-      <input type="text" name="vocabulary-ar" class="form-control" dir="rtl">
-    </div>
+    {{ form.input('vocabulary', label =_('EN NAME'), value=data.name, error=errors.name)}}
+    {{ form.input('vocabulary-ar', label =_('AR NAME'), value=data.name_translated.ar if data.name_translated else  '' )}}
+    {{ form.markdown('description-en', id='description-en', label=_('EN Description'), 
+        value= data.description_translated.en if data.description_translated else  '' )}}
+    {{ form.markdown('description-ar', id='description-ar', label=_('AR Description'), 
+        value=data.description_translated.ar if data.description_translated else '', attrs={'dir': 'rtl'} )}}
+  
 
     <div class="form-group" >
       <h2 class="page-header" style="color:#2f88a3;">{{ _('Add Tags') }}</h2>

--- a/ckanext/vocabulary/templates/vocabulary/new.html
+++ b/ckanext/vocabulary/templates/vocabulary/new.html
@@ -14,14 +14,22 @@
 {% block primary_content_inner %}
     {% set flash_messages = h.flash.pop_messages() %}
     {{ h.literal(message) }}
-  <form class="dataset-form" method="post" data-module="basic-form">
+  <form class="dataset-form" method="post" data-module="basic-form" enctype="multipart/form-data">
     {{ form.input('vocabulary', label =_('EN NAME'), value=data.name, error=errors.name)}}
     {{ form.input('vocabulary-ar', label =_('AR NAME'), value=data.name_translated.ar if data.name_translated else  '' )}}
     {{ form.markdown('description-en', id='description-en', label=_('EN Description'), 
         value= data.description_translated.en if data.description_translated else  '' )}}
     {{ form.markdown('description-ar', id='description-ar', label=_('AR Description'), 
         value=data.description_translated.ar if data.description_translated else '', attrs={'dir': 'rtl'} )}}
-  
+
+    {% set is_image_upload = data.image_url and not data.image_url.startswith('http') %}
+    {% set is_image_url = data.image_url and data.image_url.startswith('http') %}
+    {{ form.image_upload(data, errors, is_upload_enabled=h.uploads_enabled(), is_url=is_image_url, is_upload=is_image_upload) }}
+
+    {% set is_icon_upload = data.icon_url and not data.icon_url.startswith('http') %}
+    {% set is_icon_url = data.icon_url and data.icon_url.startswith('http') %}
+    {{ form.image_upload(data, errors, is_upload_enabled=h.uploads_enabled(), field_upload='icon_upload',
+    field_url='icon_url', upload_label='Icon', url_label='Icon', is_url=is_icon_url, is_upload=is_icon_upload, ) }}
 
     <div class="form-group" >
       <h2 class="page-header" style="color:#2f88a3;">{{ _('Add Tags') }}</h2>
@@ -51,6 +59,8 @@
   {% snippet "vocabulary/snippets/helper.html" %}
 {% endblock %}
 {% block scripts %}
+   {{super()}}
+  {% asset 'ckanext-scheming/upload_js' %}
   {% asset 'vocab/addtags_js' %}
 {% endblock %}
 


### PR DESCRIPTION
**Fix for** : https://github.com/FCSCOpendata/ckanext-fcscopendata/issues/40

This PR is dependent on  https://github.com/FCSCOpendata/ckanext-fcscopendata/pull/43.

## Following changes are Included. 
-  [Improvement] Raw HTML input fields are replaced with CKAN jinja macros template. 
-  [Improvement] Validation error behavior improvement. 
-  Updated template adding an additional fields for icon and image upload. 
-  Updated Vocab controller to prepare data_dict including icon and image params.  